### PR TITLE
Generate SSH key via Terraform + Add Sausage cloud

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -10,6 +10,13 @@ jobs:
   terraform:
     name: "Terraform"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace:
+          - vglab
+          - sausage
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -28,7 +35,7 @@ jobs:
         id: init
         run: terraform init
         env:
-          TF_WORKSPACE: ${{ secrets.TF_WORKSPACE }}
+          TF_WORKSPACE: ${{ matrix.workspace }}
 
       - name: Terraform Plan
         id: plan
@@ -36,7 +43,7 @@ jobs:
         run: terraform plan -no-color
         continue-on-error: true
         env:
-          TF_WORKSPACE: ${{ secrets.TF_WORKSPACE }}
+          TF_WORKSPACE: ${{ matrix.workspace }}
 
       - uses: actions/github-script@0.9.0
         if: github.event_name == 'pull_request'
@@ -45,15 +52,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            const output = `#### Terraform Workspace 🛠️\`${{ matrix.workspace }}\`
+            #### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
             <details><summary>Show Plan</summary>
 
             \`\`\`${process.env.PLAN}\`\`\`
+
             </details>
 
-            #### Action: \`${{ github.event_name }}\` by @${{ github.actor }}`;
+            #### Author ✍️@${{ github.actor }}`;
               
             github.issues.createComment({
               issue_number: context.issue.number,
@@ -69,4 +78,4 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: terraform apply -auto-approve
         env:
-          TF_WORKSPACE: ${{ secrets.TF_WORKSPACE }}
+          TF_WORKSPACE: ${{ matrix.workspace }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-vglab-bastion
-=============
+bastion-terraform
+=================
 
 This repo contains Terraform script for provisioning a bastion host and
 managing users on the instance.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "users" {
-  value = keys(null_resource.users)
+  value = local.users
 }
 
 output "fip" {

--- a/provider.tf
+++ b/provider.tf
@@ -17,5 +17,5 @@ terraform {
 }
 
 provider "openstack" {
-  cloud = var.cloud
+  cloud = "openstack"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,10 +18,6 @@ variable "flavor" {
   default = "2d838268-d90e-4db0-8023-7a3638805313" # general.v1.tiny
 }
 
-variable "key_pair" {
-  default = "bharat-mac"
-}
-
 variable "user" {
   default = "ubuntu"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,27 +1,38 @@
 variable "fip" {
-  default = "185.45.78.150"
+  type = string
 }
 
 variable "name" {
-  default = "vglab-bastion"
+  type = string
 }
 
 variable "network" {
-  default = "ovn-network"
+  type = string
 }
 
 variable "image" {
-  default = "34a622a7-703e-4d43-b116-6fe92f04de14" # Ubuntu-20.04
+  type = string
 }
 
 variable "flavor" {
-  default = "2d838268-d90e-4db0-8023-7a3638805313" # general.v1.tiny
+  type = string
 }
 
 variable "user" {
   default = "ubuntu"
+  type    = string
 }
 
-variable "cloud" {
-  default = "openstack"
+variable "public_key" {
+  type = string
+}
+
+variable "private_key" {
+  sensitive = true
+  type      = string
+}
+
+variable "sudoers" {
+  default = []
+  type    = list(string)
 }


### PR DESCRIPTION
This is necessary because Terraform needs to be able to SSH into the instance remotely but needs ownership of the private key. This will destroy the current bastion and recreate a new one.